### PR TITLE
Fix : Blue-Green 배포 시 Nginx DNS 캐시로 인한 502 오류 수정

### DIFF
--- a/com.peopleground.sagwim.fe/nginx.conf
+++ b/com.peopleground.sagwim.fe/nginx.conf
@@ -1,13 +1,16 @@
-upstream backend {
-    server backend:8080;
-}
-
 server {
     listen 80;
     server_name _;
 
     root /usr/share/nginx/html;
     index index.html;
+
+    # Docker 내장 DNS resolver — Blue-Green 배포 시 컨테이너 IP가 바뀌어도
+    # Nginx가 매 요청마다 'backend' 호스트명을 재조회하도록 강제한다.
+    # upstream 블록 방식은 기동 시점 IP를 고정하기 때문에 Blue 컨테이너가
+    # 교체되면 죽은 IP로 계속 요청을 보내 502/연결오류가 발생한다.
+    resolver 127.0.0.11 valid=5s ipv6=off;
+    set $backend_host "backend:8080";
 
     # Gzip 압축
     gzip on;
@@ -34,8 +37,10 @@ server {
     }
 
     # API 역방향 프록시 → 백엔드 컨테이너
+    # $backend_host 변수를 사용해야 resolver가 매 요청마다 DNS를 재조회한다.
+    # 변수 없이 literal 호스트명을 쓰면 upstream 블록과 동일하게 IP가 캐시된다.
     location /api/ {
-        proxy_pass http://backend;
+        proxy_pass http://$backend_host;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
@@ -47,13 +52,13 @@ server {
 
     # Swagger UI 프록시
     location /swagger-ui/ {
-        proxy_pass http://backend;
+        proxy_pass http://$backend_host;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }
 
     location /v3/api-docs {
-        proxy_pass http://backend;
+        proxy_pass http://$backend_host;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -136,6 +136,17 @@ deploy_backend() {
     docker rename "$green" "$blue"
     log_ok "Green → Blue 이름 변경 완료"
 
+    # Nginx upstream DNS 캐시 갱신 (필수)
+    # Nginx는 컨테이너 기동 시 upstream 호스트명(backend)을 DNS resolve해서
+    # IP를 캐시한다. Blue가 교체된 뒤 reload 없이는 죽은 IP로 계속 요청을 보낸다.
+    if docker ps -q -f name="sagwim-frontend" | grep -q .; then
+        log_info "Nginx upstream 갱신을 위해 reload 중..."
+        docker exec sagwim-frontend nginx -s reload
+        log_ok "Nginx reload 완료"
+    else
+        log_warn "sagwim-frontend 컨테이너가 없어 Nginx reload를 건너뜁니다."
+    fi
+
     log_ok "===== 백엔드 배포 완료 ====="
 }
 


### PR DESCRIPTION
- nginx.conf: upstream 블록 제거 후 Docker 내장 DNS resolver(127.0.0.11) + 변수 방식($backend_host)으로 교체하여 매 요청마다 DNS를 재조회하도록 수정
- deploy.sh: Blue→Green 컨테이너 교체 완료 후 Nginx reload 누락 문제 수정