### PR TITLE
Fix : favicon 캐시 장기 고착 문제 해결 (nginx exact match + 쿼리스트링 버전)

### DIFF
--- a/com.peopleground.sagwim.fe/index.html
+++ b/com.peopleground.sagwim.fe/index.html
@@ -2,8 +2,8 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="apple-touch-icon" href="/logo.svg?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- 기본 SEO -->

--- a/com.peopleground.sagwim.fe/nginx.conf
+++ b/com.peopleground.sagwim.fe/nginx.conf
@@ -69,6 +69,13 @@ server {
         proxy_set_header Host $host;
     }
 
+    # favicon — 자주 바뀔 수 있으므로 짧게 캐시 (1일)
+    location = /favicon.svg {
+        expires 1d;
+        add_header Cache-Control "public, max-age=86400";
+        try_files $uri =404;
+    }
+
     # 정적 파일 캐시 (해시 포함 빌드 산출물: 1년)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
- nginx에 favicon.svg 전용 exact match 블록 추가 (Cache-Control: 1일)
- 기존 정규식 ~* SVG 1년 캐시보다 우선 적용되도록 앞에 배치
- index.html favicon/apple-touch-icon href에 ?v=2 쿼리스트링 추가 (브라우저·Cloudflare가 새 URL로 인식해 즉시 갱신)

## 관련 이슈

Closes #

---

## PR 유형

- [ ] `feat` — 새로운 기능 추가
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 기능 변경 없는 코드 개선
- [ ] `style` — 코드 포맷, 공백 등 스타일 변경
- [ ] `docs` — 문서 추가 또는 수정
- [ ] `chore` — 빌드 설정, 패키지 업데이트 등 기타 작업
- [ ] `test` — 테스트 코드 추가 또는 수정

---

## 작업 내용

- 

---

## 스크린샷 (선택)

> UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요.

---

## 테스트 확인

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 빌드가 성공적으로 완료되었습니다.
- [ ] 관련 기능에 회귀(regression)가 없음을 확인했습니다.

---

## 리뷰어 참고사항 (선택)

> 리뷰어가 집중해서 봐야 할 부분이나 특이사항을 작성해주세요.
