### PR TITLE
Fix : 유효하지 않은 roomId(-1) 채팅방 메시지 조회/구독 차단

### DIFF
--- a/com.peopleground.sagwim.app/app/(app)/chat-room.tsx
+++ b/com.peopleground.sagwim.app/app/(app)/chat-room.tsx
@@ -50,7 +50,8 @@ export default function ChatRoomScreen() {
 
   const loadMessages = useCallback(
     async (nextCursor?: number) => {
-      if (!roomId) return
+      // Number(params.roomId) 가 NaN/-1/0 인 비정상 진입(딥링크 등)을 모두 차단한다.
+      if (!Number.isFinite(roomId) || roomId <= 0) return
       setLoading(true)
       try {
         const res = await fetchMessages(roomId, nextCursor)
@@ -77,7 +78,7 @@ export default function ChatRoomScreen() {
 
   // 읽음 처리: 낙관적 메시지(음수 id)는 건너뛴다.
   useEffect(() => {
-    if (messages.length === 0) return
+    if (!Number.isFinite(roomId) || roomId <= 0 || messages.length === 0) return
     const lastId = messages[0].id
     if (lastId <= 0) return
     void markAsRead(roomId, lastId).catch(() => null)
@@ -105,6 +106,8 @@ export default function ChatRoomScreen() {
   const handleSend = () => {
     const content = draft.trim()
     if (!content) return
+    // roomId 가 유효하지 않으면 전송하지 않는다(비정상 진입 방어).
+    if (!Number.isFinite(roomId) || roomId <= 0) return
     const tempId = optimisticIdCounter--
     const optimistic: ChatMessage = {
       id: tempId,

--- a/com.peopleground.sagwim.app/src/hooks/useChatSocket.ts
+++ b/com.peopleground.sagwim.app/src/hooks/useChatSocket.ts
@@ -20,7 +20,8 @@ export function useChatRoom({ roomId, onMessage }: UseChatRoomOptions) {
   }, [onMessage])
 
   useEffect(() => {
-    if (roomId === null) return
+    // roomId 가 없거나 유효하지 않은 값이면 구독하지 않는다.
+    if (roomId === null || roomId <= 0) return
     const handlerId = chatSocket.subscribeRoom(roomId, (msg) => handlerRef.current(msg))
     return () => {
       chatSocket.unsubscribeRoom(roomId, handlerId)

--- a/com.peopleground.sagwim.fe/src/components/chat/ChatRoomView.tsx
+++ b/com.peopleground.sagwim.fe/src/components/chat/ChatRoomView.tsx
@@ -32,7 +32,8 @@ export function ChatRoomView({ roomId, roomSummary, myUsername }: Props) {
 
   const loadMessages = useCallback(
     async (nextCursor?: number) => {
-      if (!token) return
+      // roomId 가 유효하지 않으면(채팅방 미선택 placeholder -1 등) 조회하지 않는다.
+      if (!token || roomId <= 0) return
       setLoading(true)
       try {
         const res = await fetchMessages(token, roomId, nextCursor)
@@ -68,7 +69,7 @@ export function ChatRoomView({ roomId, roomSummary, myUsername }: Props) {
 
   // 읽음 처리: 낙관적 메시지(음수 id)는 아직 서버에 저장되지 않았으므로 건너뛴다.
   useEffect(() => {
-    if (!token || messages.length === 0) return
+    if (!token || roomId <= 0 || messages.length === 0) return
     const lastId = messages[0].id
     if (lastId <= 0) return
     void markAsRead(token, roomId, lastId).catch(() => null)
@@ -97,6 +98,8 @@ export function ChatRoomView({ roomId, roomSummary, myUsername }: Props) {
   })
 
   const handleSend = (content: string) => {
+    // roomId 가 유효하지 않으면 전송하지 않는다(placeholder 상태 방어).
+    if (roomId <= 0) return
     // 낙관적 업데이트: 서버 echo를 기다리지 않고 즉시 화면에 표시한다.
     // 임시 id로 음수 값을 사용하므로 서버 id(양수)와 충돌하지 않는다.
     const tempId = optimisticIdCounter--

--- a/com.peopleground.sagwim.fe/src/hooks/useChatSocket.ts
+++ b/com.peopleground.sagwim.fe/src/hooks/useChatSocket.ts
@@ -46,7 +46,8 @@ export function useChatRoom({ roomId, onMessage }: UseChatRoomOptions) {
   }, [onMessage])
 
   useEffect(() => {
-    if (roomId === null) return
+    // roomId 가 없거나 유효하지 않은 값(placeholder -1 등)이면 구독하지 않는다.
+    if (roomId === null || roomId <= 0) return
 
     // subscribeRoom은 핸들러 식별자(symbol)를 반환한다.
     // 소켓이 아직 연결 중이면 chatSocket 내부 큐에 적재되었다가


### PR DESCRIPTION
채팅방 미선택 placeholder 상태에서 roomId=-1로 메시지 조회·소켓 구독이
발생해 백엔드 403(NOT_ROOM_MEMBER) 에러 로그가 쌓이던 문제 수정.
웹/RN 양쪽 loadMessages·읽음처리·전송·useChatRoom 구독에 roomId<=0 가드 추가.

## 관련 이슈

Closes #

---

## PR 유형

- [ ] `feat` — 새로운 기능 추가
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 기능 변경 없는 코드 개선
- [ ] `style` — 코드 포맷, 공백 등 스타일 변경
- [ ] `docs` — 문서 추가 또는 수정
- [ ] `chore` — 빌드 설정, 패키지 업데이트 등 기타 작업
- [ ] `test` — 테스트 코드 추가 또는 수정

---

## 작업 내용

- 

---

## 스크린샷 (선택)

> UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요.

---

## 테스트 확인

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 빌드가 성공적으로 완료되었습니다.
- [ ] 관련 기능에 회귀(regression)가 없음을 확인했습니다.

---

## 리뷰어 참고사항 (선택)

> 리뷰어가 집중해서 봐야 할 부분이나 특이사항을 작성해주세요.
