### PR TITLE
Refactor : 클라이언트 설정 페이지를 모달형에서 서비스 UI 레이아웃으로 재구성 — 헤더와 동일한 1080px 컨테이…

### DIFF
--- a/com.peopleground.sagwim.fe/src/pages/SettingsPage.module.css
+++ b/com.peopleground.sagwim.fe/src/pages/SettingsPage.module.css
@@ -1,40 +1,534 @@
-/* ── SettingsPage ── */
+/* ── SettingsPage — SaaS 스타일 재설계 ── */
+
+/* ── 페이지 래퍼 ── */
 .main {
-  display: flex;
-  justify-content: center;
-  min-height: 100dvh;
-  padding: var(--sp-8) var(--sp-6);
-  padding-left: calc(var(--layout-sidebar-w) + var(--sp-6));
-  padding-bottom: calc(var(--sp-8) + var(--layout-bottom-bar-h));
+  width: 100%;
+  min-height: calc(100dvh - var(--layout-header-h));
+  padding-bottom: calc(var(--sp-16) + var(--layout-bottom-bar-h));
 }
 
-.container {
-  width: 100%;
-  max-width: 600px;
+/* ── 히어로 배너 (헤더와 동일한 1080px 컨테이너에 정렬) ── */
+.hero {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding-top: var(--sp-8);
+  padding-right: var(--sp-6);
+  padding-left: calc(var(--layout-sidebar-w) + var(--sp-6));
+}
+
+.heroInner {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+  padding: var(--sp-6) var(--sp-8);
+  background:
+    linear-gradient(135deg, var(--clr-accent-muted) 0%, transparent 60%),
+    var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+}
+
+.heroIconWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--r-xl);
+  background: var(--clr-accent-gradient);
+  color: var(--clr-on-accent);
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px var(--clr-accent-glow);
+}
+
+.heroEyebrow {
+  margin: 0 0 var(--sp-1);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--clr-accent);
+}
+
+.heroTitle {
+  margin: 0 0 var(--sp-2);
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--clr-text);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.heroSubtitle {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--clr-text-secondary);
+  line-height: 1.5;
+}
+
+/* ── 본문 레이아웃 (헤더와 동일한 1080px 컨테이너) ── */
+.layout {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: var(--sp-6);
+  padding-top: var(--sp-6);
+  padding-left: calc(var(--layout-sidebar-w) + var(--sp-6));
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--sp-6);
+  align-items: flex-start;
+}
+
+/* ── 좌측 사이드바 탭 ── */
+.sidebar {
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  padding: var(--sp-4) var(--sp-3);
   display: flex;
   flex-direction: column;
-  background: var(--clr-surface);
-  border-radius: var(--r-xl);
-  border: 1px solid var(--clr-border);
-  overflow: hidden;
+  gap: var(--sp-2);
+  position: sticky;
+  top: calc(var(--layout-header-h) + var(--sp-4));
 }
 
-.body {
+.sidebarHeading {
+  margin: 0 0 var(--sp-1);
+  padding: 0 var(--sp-2);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--clr-text-muted);
+}
+
+.tabList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* 탭 아이템 공통 */
+.tabItem {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--r-md);
+  cursor: pointer;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--clr-text-secondary);
+  transition: background var(--t-fast), color var(--t-fast);
+  text-align: left;
+}
+
+.tabItem:hover {
+  background: var(--clr-surface-2);
+  color: var(--clr-text);
+}
+
+.tabItem:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+/* 활성 탭 — 코랄 muted 배경 */
+.tabItemActive {
+  composes: tabItem;
+  background: var(--clr-accent-muted);
+  color: var(--clr-accent);
+  font-weight: 700;
+}
+
+.tabItemActive:hover {
+  background: var(--clr-accent-muted);
+  color: var(--clr-accent);
+}
+
+.tabIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: color var(--t-fast);
+}
+
+.tabLabel {
   flex: 1;
 }
 
-@media (max-width: 767px) {
+/* 활성 탭 우측 도트 인디케이터 */
+.tabActiveIndicator {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--r-full);
+  background: var(--clr-accent);
+  flex-shrink: 0;
+}
+
+/* 사이드바 하단 장식 */
+.sidebarFooter {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-2) var(--sp-1);
+  margin-top: auto;
+  border-top: 1px solid var(--clr-border);
+  font-size: 0.75rem;
+  color: var(--clr-text-muted);
+}
+
+/* ── 우측 콘텐츠 ── */
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  min-width: 0;
+}
+
+/* 패널 헤더 */
+.panelHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-4);
+}
+
+.panelTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.375rem;
+  font-weight: 800;
+  color: var(--clr-text);
+  letter-spacing: -0.01em;
+}
+
+.panelSubtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--clr-text-secondary);
+  line-height: 1.5;
+}
+
+/* ── 기능 카드 그리드 ── */
+.cardGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-3);
+}
+
+/* 기능 카드 공통 */
+.featureCard {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  padding: var(--sp-5) var(--sp-6);
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast),
+    transform var(--t-fast);
+}
+
+.featureCard:hover {
+  border-color: var(--clr-accent);
+  box-shadow: 0 0 0 3px var(--clr-accent-muted), var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.featureCard:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
+.featureCard:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus), var(--shadow-sm);
+}
+
+/* 아이콘 래퍼 */
+.featureCardIconWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--r-lg);
+  background: var(--clr-accent-muted);
+  color: var(--clr-accent);
+  flex-shrink: 0;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+
+.featureCard:hover .featureCardIconWrap {
+  background: var(--clr-accent);
+  color: var(--clr-on-accent);
+}
+
+.featureCardBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.featureCardTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-text);
+}
+
+.featureCardDesc {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--clr-text-secondary);
+  line-height: 1.5;
+}
+
+.featureCardArrow {
+  display: inline-flex;
+  color: var(--clr-text-muted);
+  flex-shrink: 0;
+  transition: color var(--t-fast), transform var(--t-fast);
+}
+
+.featureCard:hover .featureCardArrow {
+  color: var(--clr-accent);
+  transform: translateX(2px);
+}
+
+/* ── 위험 구역 ── */
+.dangerZone {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.dangerZoneHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  color: var(--clr-error);
+}
+
+.dangerZoneLabel {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* 위험 카드 — error 색상 계열 */
+.dangerCard {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  padding: var(--sp-5) var(--sp-6);
+  background: var(--clr-surface);
+  border: 1px solid color-mix(in srgb, var(--clr-error) 22%, transparent);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast),
+    transform var(--t-fast);
+}
+
+.dangerCard:hover {
+  border-color: var(--clr-error);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--clr-error) 14%, transparent),
+    var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.dangerCard:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
+.dangerCard:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--clr-error) 24%, transparent),
+    0 0 0 1px var(--clr-error);
+}
+
+.dangerCardIconWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--r-lg);
+  background: var(--clr-error-soft);
+  color: var(--clr-error);
+  flex-shrink: 0;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+
+.dangerCard:hover .dangerCardIconWrap {
+  background: var(--clr-error);
+  color: #ffffff;
+}
+
+.dangerCardBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.dangerCardTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--clr-error);
+}
+
+.dangerCardDesc {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--clr-text-secondary);
+  line-height: 1.5;
+}
+
+.dangerCardArrow {
+  display: inline-flex;
+  color: var(--clr-error);
+  opacity: 0.5;
+  flex-shrink: 0;
+  transition: opacity var(--t-fast), transform var(--t-fast);
+}
+
+.dangerCard:hover .dangerCardArrow {
+  opacity: 1;
+  transform: translateX(2px);
+}
+
+/* ── 반응형 ── */
+
+/* 태블릿: 사이드바 폭만 축소(좌우 패딩은 헤더와 동일 유지) */
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 180px 1fr;
+    gap: var(--sp-4);
+  }
+}
+
+/* 모바일: 좌측 탭 → 상단 수평 스크롤 pill 탭바 */
+@media (max-width: 640px) {
   .main {
-    padding: 0;
-    padding-left: var(--layout-sidebar-w);
-    padding-bottom: var(--layout-bottom-bar-h);
-    align-items: flex-start;
+    padding-bottom: calc(var(--sp-12) + var(--layout-bottom-bar-h));
   }
 
-  .container {
-    max-width: none;
-    border-radius: 0;
-    border: none;
-    min-height: calc(100dvh - var(--layout-bottom-bar-h));
+  .hero {
+    padding: var(--sp-6) var(--sp-4) 0;
+  }
+
+  .heroInner {
+    gap: var(--sp-4);
+    padding: var(--sp-5);
+    align-items: center;
+  }
+
+  .heroIconWrap {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--r-lg);
+  }
+
+  .heroTitle {
+    font-size: 1.5rem;
+  }
+
+  .heroSubtitle {
+    font-size: 0.875rem;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    padding: var(--sp-4);
+    padding-left: calc(var(--layout-sidebar-w) + var(--sp-4));
+    gap: var(--sp-4);
+  }
+
+  .sidebar {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--sp-2);
+    padding: var(--sp-2) var(--sp-3);
+    overflow-x: auto;
+    scrollbar-width: none;
+    border-radius: var(--r-lg);
+  }
+
+  .sidebar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .sidebarHeading,
+  .sidebarFooter {
+    display: none;
+  }
+
+  .tabList {
+    flex-direction: row;
+    gap: var(--sp-2);
+    flex-shrink: 0;
+  }
+
+  .tabItem,
+  .tabItemActive {
+    white-space: nowrap;
+    padding: var(--sp-2) var(--sp-3);
+    font-size: 0.875rem;
+    border-radius: var(--r-full);
+  }
+
+  .tabActiveIndicator {
+    display: none;
+  }
+
+  .featureCard,
+  .dangerCard {
+    padding: var(--sp-4);
+    gap: var(--sp-3);
+  }
+
+  .featureCardIconWrap,
+  .dangerCardIconWrap {
+    width: 40px;
+    height: 40px;
+  }
+
+  .featureCardTitle,
+  .dangerCardTitle {
+    font-size: 0.9375rem;
   }
 }

--- a/com.peopleground.sagwim.fe/src/pages/SettingsPage.tsx
+++ b/com.peopleground.sagwim.fe/src/pages/SettingsPage.tsx
@@ -1,12 +1,49 @@
+import { useState } from 'react'
+import type { ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useHandleUnauthorized } from '../hooks/useHandleUnauthorized'
 import { useLogout } from '../hooks/useLogout'
 import { Navbar } from '../components/Navbar'
 import { Header } from '../components/Header'
-import styles from '../components/profile/ProfileEditModal.module.css'
-import pageStyles from './SettingsPage.module.css'
-import listStyles from './ProfileEditPage.module.css'
+import { MobileHeader } from '../components/MobileHeader'
+import { Footer } from '../components/Footer'
+import { ShieldIcon, UserCircleIcon, AlertIcon, SettingsIcon } from '../components/NavIcons'
+import styles from './SettingsPage.module.css'
+
+type TabId = 'account'
+
+interface SideTab {
+  id: TabId
+  label: string
+  icon: ReactNode
+}
+
+const TABS: SideTab[] = [
+  {
+    id: 'account',
+    label: '계정 보안',
+    icon: <ShieldIcon width={18} height={18} />,
+  },
+]
+
+function ChevronRight() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m9 6 6 6-6 6" />
+    </svg>
+  )
+}
 
 export function SettingsPage() {
   const navigate = useNavigate()
@@ -14,50 +51,138 @@ export function SettingsPage() {
   useHandleUnauthorized()
   const handleLogout = useLogout()
 
+  const [activeTab, setActiveTab] = useState<TabId>('account')
+
   return (
     <>
       <Navbar role={meRole} onLogout={handleLogout} />
       <Header role={meRole} onLogout={handleLogout} />
+      <MobileHeader onLogout={handleLogout} />
 
-      <main className={pageStyles.main}>
-        <div className={pageStyles.container}>
-          <header className={styles.header}>
-            <button
-              type="button"
-              className={styles.headerBtn}
-              onClick={() => navigate(-1)}
-            >
-              돌아가기
-            </button>
-            <h1 className={styles.title}>설정</h1>
-            <span style={{ minWidth: '4rem' }} />
-          </header>
+      <main className={styles.main}>
+        {/* ── 히어로 배너 ── */}
+        <header className={styles.hero}>
+          <div className={styles.heroInner}>
+            <div className={styles.heroIconWrap} aria-hidden="true">
+              <SettingsIcon width={28} height={28} />
+            </div>
+            <div>
+              <p className={styles.heroEyebrow}>내 계정</p>
+              <h1 className={styles.heroTitle}>설정</h1>
+              <p className={styles.heroSubtitle}>계정과 보안을 관리하세요</p>
+            </div>
+          </div>
+        </header>
 
-          <div className={pageStyles.body}>
-            <ul className={listStyles.settingList}>
-              <li
-                className={listStyles.settingRow}
-                onClick={() => navigate('/app/settings/change-password')}
-              >
-                <span className={listStyles.settingLabel}>비밀번호 변경</span>
-                <span className={listStyles.chevron} style={{ marginLeft: 'auto' }}>›</span>
-              </li>
-              <li
-                className={listStyles.settingRow}
-                onClick={() => navigate('/app/settings/withdraw')}
-              >
-                <span
-                  className={listStyles.settingLabel}
-                  style={{ color: 'var(--clr-error)' }}
-                >
-                  회원 탈퇴
-                </span>
-                <span className={listStyles.chevron} style={{ marginLeft: 'auto' }}>›</span>
-              </li>
+        {/* ── 본문: 좌측 탭 + 우측 콘텐츠 ── */}
+        <div className={styles.layout}>
+          {/* 좌측 세로 탭 네비게이션 */}
+          <nav className={styles.sidebar} aria-label="설정 카테고리">
+            <p className={styles.sidebarHeading}>메뉴</p>
+            <ul className={styles.tabList} role="tablist">
+              {TABS.map((tab) => {
+                const isActive = activeTab === tab.id
+                return (
+                  <li key={tab.id} role="none">
+                    <button
+                      type="button"
+                      id={`tab-${tab.id}`}
+                      role="tab"
+                      aria-selected={isActive}
+                      aria-controls={`panel-${tab.id}`}
+                      className={isActive ? styles.tabItemActive : styles.tabItem}
+                      onClick={() => setActiveTab(tab.id)}
+                    >
+                      <span className={styles.tabIcon} aria-hidden="true">
+                        {tab.icon}
+                      </span>
+                      <span className={styles.tabLabel}>{tab.label}</span>
+                      {isActive && (
+                        <span className={styles.tabActiveIndicator} aria-hidden="true" />
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
             </ul>
+
+            <div className={styles.sidebarFooter}>
+              <UserCircleIcon width={14} height={14} />
+              <span>개인 설정</span>
+            </div>
+          </nav>
+
+          {/* 우측 콘텐츠 패널 */}
+          <div
+            id="panel-account"
+            role="tabpanel"
+            aria-labelledby="tab-account"
+            className={styles.content}
+          >
+            <div className={styles.panelHeader}>
+              <div className={styles.panelTitleGroup}>
+                <h2 className={styles.panelTitle}>계정 보안</h2>
+                <p className={styles.panelSubtitle}>
+                  비밀번호 변경 및 계정 관련 설정을 관리합니다
+                </p>
+              </div>
+            </div>
+
+            {/* 기능 카드 그리드 */}
+            <div className={styles.cardGrid}>
+              <button
+                type="button"
+                className={styles.featureCard}
+                onClick={() => navigate('/app/settings/change-password')}
+                aria-label="비밀번호 변경 페이지로 이동"
+              >
+                <div className={styles.featureCardIconWrap} aria-hidden="true">
+                  <ShieldIcon width={22} height={22} />
+                </div>
+                <div className={styles.featureCardBody}>
+                  <p className={styles.featureCardTitle}>비밀번호 변경</p>
+                  <p className={styles.featureCardDesc}>
+                    정기적인 비밀번호 변경으로 계정을 안전하게 보호하세요
+                  </p>
+                </div>
+                <div className={styles.featureCardArrow} aria-hidden="true">
+                  <ChevronRight />
+                </div>
+              </button>
+            </div>
+
+            {/* 위험 구역 섹션 */}
+            <div className={styles.dangerZone}>
+              <div className={styles.dangerZoneHeader}>
+                <AlertIcon width={16} height={16} />
+                <span className={styles.dangerZoneLabel}>위험 구역</span>
+              </div>
+
+              <button
+                type="button"
+                className={styles.dangerCard}
+                onClick={() => navigate('/app/settings/withdraw')}
+                aria-label="회원 탈퇴 페이지로 이동"
+              >
+                <div className={styles.dangerCardIconWrap} aria-hidden="true">
+                  <AlertIcon width={22} height={22} />
+                </div>
+                <div className={styles.dangerCardBody}>
+                  <p className={styles.dangerCardTitle}>회원 탈퇴</p>
+                  <p className={styles.dangerCardDesc}>
+                    탈퇴 후 모든 데이터는 복구할 수 없습니다. 신중하게 결정해 주세요
+                  </p>
+                </div>
+                <div className={styles.dangerCardArrow} aria-hidden="true">
+                  <ChevronRight />
+                </div>
+              </button>
+            </div>
           </div>
         </div>
       </main>
+
+      <Footer />
     </>
   )
 }


### PR DESCRIPTION
…너 안에 코랄 배너 카드 + 좌측 세로탭(계정 보안) + 우측 기능 카드(비밀번호 변경)·위험 구역(회원 탈퇴) 구성. 공용 Footer·MobileHeader 추가, danger 계열은 color-mix로 다크모드 안전 처리. 모바일에서는 좌측탭이 상단 수평 pill 탭바로 전환

## 관련 이슈

Closes #

---

## PR 유형

- [ ] `feat` — 새로운 기능 추가
- [ ] `fix` — 버그 수정
- [ ] `refactor` — 기능 변경 없는 코드 개선
- [ ] `style` — 코드 포맷, 공백 등 스타일 변경
- [ ] `docs` — 문서 추가 또는 수정
- [ ] `chore` — 빌드 설정, 패키지 업데이트 등 기타 작업
- [ ] `test` — 테스트 코드 추가 또는 수정

---

## 작업 내용

- 

---

## 스크린샷 (선택)

> UI 변경이 있는 경우 Before / After 스크린샷을 첨부해주세요.

---

## 테스트 확인

- [ ] 로컬에서 정상 동작을 확인했습니다.
- [ ] 빌드가 성공적으로 완료되었습니다.
- [ ] 관련 기능에 회귀(regression)가 없음을 확인했습니다.

---

## 리뷰어 참고사항 (선택)

> 리뷰어가 집중해서 봐야 할 부분이나 특이사항을 작성해주세요.
